### PR TITLE
fix: typos destory -> destroy

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -51,7 +51,7 @@ declare class Danmaku {
   /**
    * Destroy the instance and release memory.
    */
-  destory(): Danmaku;
+  destroy(): Danmaku;
   emit(comment: Comment): Danmaku;
   show(): Danmaku;
   hide(): Danmaku;


### PR DESCRIPTION
修改 Typescript 声明文件的錯字。