### PR TITLE
Use requestAnimationFrame's timestamp

### DIFF
--- a/src/api/emit.js
+++ b/src/api/emit.js
@@ -1,4 +1,4 @@
-import { formatMode, binsearch } from '../utils.js';
+import { formatMode, binsearch, now } from '../utils.js';
 
 var properties = ['mode', 'time', 'text', 'render', 'style'];
 
@@ -15,7 +15,7 @@ export default function(obj) {
   }
   cmt.text = (cmt.text || '').toString();
   cmt.mode = formatMode(cmt.mode);
-  cmt._utc = Date.now() / 1000;
+  cmt._utc = now() / 1000;
   if (this.media) {
     var position = 0;
     if (cmt.time === undefined) {

--- a/src/engine/index.js
+++ b/src/engine/index.js
@@ -5,10 +5,7 @@ import { now } from '../utils.js';
 export default function(framing, setup, render, remove) {
   return function(_timestamp) {
     framing(this._.stage);
-    var timestamp = _timestamp;
-    if (typeof timestamp === 'undefined') {
-      timestamp = now();
-    }
+    var timestamp = _timestamp || now();
     var dn = timestamp / 1000;
     var ct = this.media ? this.media.currentTime : dn;
     var pbr = this.media ? this.media.playbackRate : 1;

--- a/src/engine/index.js
+++ b/src/engine/index.js
@@ -1,10 +1,15 @@
 import allocate from '../internal/allocate.js';
+import { now } from '../utils.js';
 
 /* eslint no-invalid-this: 0 */
 export default function(framing, setup, render, remove) {
-  return function() {
+  return function(_timestamp) {
     framing(this._.stage);
-    var dn = Date.now() / 1000;
+    var timestamp = _timestamp;
+    if (typeof timestamp === 'undefined') {
+      timestamp = now();
+    }
+    var dn = timestamp / 1000;
     var ct = this.media ? this.media.currentTime : dn;
     var pbr = this.media ? this.media.playbackRate : 1;
     var cmt = null;
@@ -48,8 +53,8 @@ export default function(framing, setup, render, remove) {
       cmt = this._.runningList[i];
       var totalWidth = this._.width + cmt.width;
       var elapsed = totalWidth * (dn - cmt._utc) * pbr / this._.duration;
-      if (cmt.mode === 'ltr') cmt.x = (elapsed - cmt.width + .5) | 0;
-      if (cmt.mode === 'rtl') cmt.x = (this._.width - elapsed + .5) | 0;
+      if (cmt.mode === 'ltr') cmt.x = elapsed - cmt.width;
+      if (cmt.mode === 'rtl') cmt.x = this._.width - elapsed;
       if (cmt.mode === 'top' || cmt.mode === 'bottom') {
         cmt.x = (this._.width - cmt.width) >> 1;
       }

--- a/src/internal/allocate.js
+++ b/src/internal/allocate.js
@@ -1,7 +1,9 @@
+import { now } from '../utils.js';
+
 /* eslint no-invalid-this: 0 */
 export default function(cmt) {
   var that = this;
-  var ct = this.media ? this.media.currentTime : Date.now() / 1000;
+  var ct = this.media ? this.media.currentTime : now() / 1000;
   var pbr = this.media ? this.media.playbackRate : 1;
   function willCollide(cr, cmt) {
     if (cmt.mode === 'top' || cmt.mode === 'bottom') {

--- a/src/internal/play.js
+++ b/src/internal/play.js
@@ -1,5 +1,5 @@
 import createEngine from '../engine/index.js';
-import { raf } from '../utils.js';
+import { raf, now } from '../utils.js';
 
 /* eslint no-invalid-this: 0 */
 export default function() {
@@ -10,7 +10,7 @@ export default function() {
   if (this.media) {
     for (var i = 0; i < this._.runningList.length; i++) {
       var cmt = this._.runningList[i];
-      cmt._utc = Date.now() / 1000 - (this.media.currentTime - cmt.time);
+      cmt._utc = now() / 1000 - (this.media.currentTime - cmt.time);
     }
   }
   var that = this;
@@ -20,8 +20,8 @@ export default function() {
     this._.engine.render.bind(this),
     this._.engine.remove.bind(this)
   );
-  function frame() {
-    engine.call(that);
+  function frame(timestamp) {
+    engine.call(that, timestamp);
     that._.requestID = raf(frame);
   }
   this._.requestID = raf(frame);

--- a/src/utils.js
+++ b/src/utils.js
@@ -62,3 +62,9 @@ export function resetSpace(space) {
   space.top = collidableRange();
   space.bottom = collidableRange();
 }
+
+export function now() {
+  return typeof window.performance !== 'undefined' && window.performance.now
+    ? window.performance.now()
+    : Date.now();
+}


### PR DESCRIPTION
问题来源：https://github.com/chen3861229/dd-danmaku/issues/6#issuecomment-2361572396

抖动应该是由于使用了 Date.now() 进行计时以及整数取整造成的

所以解决方案： 采用 requestAnimationFrame 提供的高精度 [timestamp](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame#timestamp)，并保留位置的小数部分

https://github.com/lanytcc/Danmaku/blob/fix-shake/src/engine/index.js#L5

只在这个部分做了小范围修改，刚经过我的macbook测试已经正常

已经运行过`npm run build`