### PR TITLE
fix: maybe it helps to fix 'window' is not defined in SSR

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,28 +1,26 @@
-export /* istanbul ignore next */ var raf = (
+export /* istanbul ignore next */ var raf = typeof window !== 'undefined' ?
   (
-    typeof window !== 'undefined' &&
     (
       window.requestAnimationFrame ||
       window.mozRequestAnimationFrame ||
       window.webkitRequestAnimationFrame
-    )
-  ) ||
-  function(cb) {
-    return setTimeout(cb, 50 / 3);
-  }
-).bind(window);
+    ) ||
+    function(cb) {
+      return setTimeout(cb, 50 / 3);
+    }
+  ).bind(window)
+  : () => {};
 
-export /* istanbul ignore next */ var caf = (
+export /* istanbul ignore next */ var caf = typeof window !== 'undefined' ? 
   (
-    typeof window !== 'undefined' &&
     (
       window.cancelAnimationFrame ||
       window.mozCancelAnimationFrame ||
       window.webkitCancelAnimationFrame
-    )
-  ) ||
-  clearTimeout
-).bind(window);
+    ) ||
+    clearTimeout
+  ).bind(window)
+  : () => {};
 
 export function binsearch(arr, prop, key) {
   var mid = 0;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,26 +1,28 @@
-export /* istanbul ignore next */ var raf = typeof window !== 'undefined' ?
-  (
-    (
+export /* istanbul ignore next */ var raf = (function() {
+  if (typeof window !== 'undefined') {
+    var rAF = (
       window.requestAnimationFrame ||
       window.mozRequestAnimationFrame ||
       window.webkitRequestAnimationFrame
-    ) ||
-    function(cb) {
-      return setTimeout(cb, 50 / 3);
-    }
-  ).bind(window)
-  : () => {};
+    );
+    if (rAF) return rAF.bind(window);
+  }
+  return function(cb) {
+    return setTimeout(cb, 50 / 3);
+  };
+})();
 
-export /* istanbul ignore next */ var caf = typeof window !== 'undefined' ? 
-  (
-    (
+export /* istanbul ignore next */ var caf = (function() {
+  if (typeof window !== 'undefined') {
+    var cAF = (
       window.cancelAnimationFrame ||
       window.mozCancelAnimationFrame ||
       window.webkitCancelAnimationFrame
-    ) ||
-    clearTimeout
-  ).bind(window)
-  : () => {};
+    );
+    if (cAF) return cAF.bind(window);
+  }
+  return clearTimeout;
+})();
 
 export function binsearch(arr, prop, key) {
   var mid = 0;


### PR DESCRIPTION
Danmaku related functions should not be involved in Server-Side Rendering (SSR) process, but considering that sometimes I forget to set danmaku as client-only, errors will occur here:
#### src/utils.js
``` javascript
export /* istanbul ignore next */ var raf = (
  (
    typeof window !== 'undefined' &&
    (
      window.requestAnimationFrame ||
      window.mozRequestAnimationFrame ||
      window.webkitRequestAnimationFrame
    )
  ) ||
  function(cb) {
    return setTimeout(cb, 50 / 3);
  }
).bind(window);
       ^^^^^^

export /* istanbul ignore next */ var caf = (
  (
    typeof window !== 'undefined' &&
    (
      window.cancelAnimationFrame ||
      window.mozCancelAnimationFrame ||
      window.webkitCancelAnimationFrame
    )
  ) ||
  clearTimeout
).bind(window);
       ^^^^^^
```

But I tried to write this code and open this pr while drunk, it may fix this issue or not work, just FYI.