### PR TITLE
fix: don't scale collision detection by playbackRate

### DIFF
--- a/src/internal/allocate.js
+++ b/src/internal/allocate.js
@@ -4,13 +4,16 @@ import { now } from '../utils.js';
 export default function(cmt) {
   var that = this;
   var ct = this.media ? this.media.currentTime : now() / 1000;
-  var pbr = this.media ? this.media.playbackRate : 1;
   function willCollide(cr, cmt) {
     if (cmt.mode === 'top' || cmt.mode === 'bottom') {
       return ct - cr.time < that._.duration;
     }
+    // `ct`, `cr.time` and `that._.duration` all live on the same timeline
+    // (media time when bound to a media element, wall-clock time otherwise),
+    // so `ct - cr.time` is already the elapsed travelling time on it.
+    // Scaling it by `playbackRate` would count the rate twice.
     var crTotalWidth = that._.width + cr.width;
-    var crElapsed = crTotalWidth * (ct - cr.time) * pbr / that._.duration;
+    var crElapsed = crTotalWidth * (ct - cr.time) / that._.duration;
     if (cr.width > crElapsed) {
       return true;
     }
@@ -18,7 +21,7 @@ export default function(cmt) {
     var crLeftTime = that._.duration + cr.time - ct;
     var cmtTotalWidth = that._.width + cmt.width;
     var cmtTime = that.media ? cmt.time : cmt._utc;
-    var cmtElapsed = cmtTotalWidth * (ct - cmtTime) * pbr / that._.duration;
+    var cmtElapsed = cmtTotalWidth * (ct - cmtTime) / that._.duration;
     var cmtArrival = that._.width - cmtElapsed;
     // (rtl mode) the left end of `cmt` reach the left side of stage
     var cmtArrivalTime = that._.duration * cmtArrival / (that._.width + cmt.width);

--- a/test/internal/allocate.js
+++ b/test/internal/allocate.js
@@ -1,0 +1,82 @@
+import allocate from '../../src/internal/allocate.js';
+import { resetSpace } from '../../src/utils.js';
+
+var STAGE_WIDTH = 640;
+var STAGE_HEIGHT = 360;
+// `duration` is stage width / speed, expressed in media seconds.
+var DURATION = STAGE_WIDTH / 144;
+
+// A minimal Danmaku-like host bound to a fake media element.
+function createHost(playbackRate) {
+  var host = {
+    media: { currentTime: 0, playbackRate: playbackRate },
+    _: {
+      width: STAGE_WIDTH,
+      height: STAGE_HEIGHT,
+      duration: DURATION,
+      space: {}
+    }
+  };
+  resetSpace(host._.space);
+  return host;
+}
+
+// `x` of a scrolling comment, as computed by src/engine/index.js.
+function xAt(cmt, mediaTime) {
+  var totalWidth = STAGE_WIDTH + cmt.width;
+  return STAGE_WIDTH - totalWidth * (mediaTime - cmt.time) / DURATION;
+}
+
+// Widest overlap of the on-stage parts of two comments, in px.
+function maxOverlap(a, b) {
+  var worst = 0;
+  for (var t = b.time; t <= a.time + DURATION; t += 0.01) {
+    var aLeft = Math.max(xAt(a, t), 0);
+    var aRight = Math.min(xAt(a, t) + a.width, STAGE_WIDTH);
+    var bLeft = Math.max(xAt(b, t), 0);
+    var bRight = Math.min(xAt(b, t) + b.width, STAGE_WIDTH);
+    if (aRight <= aLeft || bRight <= bLeft) continue;
+    var overlap = Math.min(aRight, bRight) - Math.max(aLeft, bLeft);
+    if (overlap > worst) worst = overlap;
+  }
+  return worst;
+}
+
+// A wide comment, then a narrower one 1.175s of media time later. The narrower
+// comment travels slower, so it can never escape the wider one: they overlap on
+// stage and must not be given the same channel.
+// `lateness` emulates rAF running a little after `cmt.time`, as it always does.
+function allocatePair(playbackRate, lateness) {
+  var host = createHost(playbackRate);
+  var a = { mode: 'rtl', time: 0, width: 630, height: 24 };
+  var b = { mode: 'rtl', time: 1.175, width: 195, height: 24 };
+  host.media.currentTime = a.time;
+  a.y = allocate.call(host, a);
+  host.media.currentTime = b.time + (lateness || 0);
+  b.y = allocate.call(host, b);
+  return { a: a, b: b };
+}
+
+describe('allocate', function() {
+  it('should keep colliding comments apart at any playbackRate', function() {
+    var rates = [0.5, 1, 1.5, 2, 3, 4];
+    var latenesses = [0, 0.016, 0.033, 0.1];
+    for (var i = 0; i < rates.length; i++) {
+      for (var j = 0; j < latenesses.length; j++) {
+        var pair = allocatePair(rates[i], latenesses[j]);
+        var where = 'playbackRate ' + rates[i] + ', lateness ' + latenesses[j] + 's';
+
+        // Guard the fixture itself: these two really do overlap on stage.
+        assert.isAbove(
+          maxOverlap(pair.a, pair.b), 30,
+          'fixture should overlap at ' + where
+        );
+
+        assert.notEqual(
+          pair.a.y, pair.b.y,
+          'comments must not share a channel at ' + where
+        );
+      }
+    }
+  });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -15,6 +15,7 @@ import './api/destroy.js';
 import './api/resize.js';
 import './api/show-hide.js';
 import './api/speed.js';
+import './internal/allocate.js';
 import './engine/canvas.js';
 import './engine/dom.js';
 import './utils.js';


### PR DESCRIPTION
Fixes #65.

## 问题

`allocate()` 把已经过去的时间乘了一次 `media.playbackRate`，但它比较的几个量本来就在媒体时间轴上：

- `ct = media.currentTime` 和 `cr.time` 都是媒体时间
- `_.duration = _.width / _.speed`，单位是媒体秒

`ct - cr.time` 已经是这条弹幕走过的时间，`* pbr` 把倍率算了第二遍。

`src/engine/index.js` 里那次乘法是必要的，因为它从墙上时钟 `dn - cmt._utc` 起算；`allocate()` 不需要。只要 `playbackRate !== 1`，两者就相差正好一个 `pbr`，分配器认为弹幕在哪、和引擎实际画在哪对不上。

同一条路径上的 `top`/`bottom` 分支（`ct - cr.time < that._.duration`）和引擎的过期判断（`ct - cmtt > this._.duration`）已经把 `_.duration` 当媒体时间、不带倍率。这个改动让滚动弹幕这一支与它们保持一致。

## 后果

`playbackRate > 1` 时被放大的距离让 `willCollide` 误判上一条弹幕已经离开入口，新弹幕被放进还被占用的轨道，两条叠在一起。`playbackRate < 1` 时反过来，判断过于保守，浪费轨道。

## 改动

去掉 `crElapsed` 和 `cmtElapsed` 两处的 `pbr` 系数，`pbr` 变量随之不再被使用。`src/engine/index.js` 未改动。

## 测试

`test/internal/allocate.js` 用一个假的 media 元素直接驱动 `allocate()`，覆盖 `playbackRate` 0.5–4，并模拟若干 rAF 延迟（rAF 不可能刚好在 `cmt.time` 触发）。用例是一条宽弹幕后面跟一条更窄、更慢、永远甩不掉它的弹幕；测试同时断言这两条确实在舞台上重叠，避免用例哪天悄悄退化成无效。

在 master 上失败：

```
allocate should keep colliding comments apart at any playbackRate FAILED
  AssertionError: comments must not share a channel at playbackRate 2, lateness 0s:
  expected 0 to not equal 0
```

打上补丁后 `npm test` 全绿（56/56，含 lint）。

## 真实浏览器验证

除单元测试外，我在真实（非 headless）Chrome 和 Firefox 窗口里对着真实 `<video>` 跑了同一个用例，用 `getBoundingClientRect()` 裁剪到可见舞台后测量重叠：

| 引擎 | playbackRate | `y` | 同轨道 | 最大重叠 |
| --- | --- | --- | --- | --- |
| Chrome 151 | 1 | `[0, 24]` | 否 | 0px |
| Chrome 151 | 2 | `[0, 0]` | 是 | 163.9px |
| Chrome 151（已修复） | 2 | `[0, 24]` | 否 | 0px |
| Firefox 153 | 1 | `[0, 24]` | 否 | 0px |
| Firefox 153 | 2 | `[0, 0]` | 是 | 0px * |
| Firefox 153（已修复） | 2 | `[0, 24]` | 否 | 0px |

\* Firefox 选中了同样错误的轨道；那次运行中第二条弹幕晚了约 65ms 创建，此时第一条已经跑开，恰好没有相交。两个引擎的分配都是错的，是否肉眼可见取决于帧落在哪里。

## 说明

`dist/` 没有重新构建，因为看起来它是在发版时（`npm version`）生成的。
